### PR TITLE
avoid duplicate nameserver entries in resolv.conf

### DIFF
--- a/nsfailover.sh
+++ b/nsfailover.sh
@@ -130,11 +130,16 @@ fi
 info "Best nameserver is ${use_level} (${use_server})"
 
 # Build new config (without comments!)
-resolvconf="nameserver ${use_server}
-nameserver ${NS_1}
-nameserver ${NS_2}
-nameserver ${NS_3}
-options timeout:${NS_TIMEOUT} attempts:${NS_ATTEMPTS}"
+resolvconf="nameserver ${use_server}\n"
+for ns in ${NS_1} ${NS_2} ${NS_3}
+do
+        if [[ "$ns" != "${use_server}" ]]
+        then
+                resolvconf+="nameserver $ns\n"
+        fi
+done
+resolvconf+="options timeout:${NS_TIMEOUT} attempts:${NS_ATTEMPTS}"
+
 # Optionally add search parameter
 [ -n "${NS_SEARCH}" ] && resolvconf="${resolvconf}
 search ${NS_SEARCH}"


### PR DESCRIPTION
currently the deemed best nameserver denoted by "use_server" will occur twice in the resolv.conf output which isn't ideal and in some circumstances could incur delayed lookups if it were to fail before the next cronjob to test for availability. 

Proposed change ensures each nameserver exists only once.
