### PR TITLE
changed to atomic file replacement

### DIFF
--- a/nsfailover.sh
+++ b/nsfailover.sh
@@ -147,7 +147,17 @@ if [ "${resolvconf}" != "${current}" ]; then
   curdate="$(date -u +"%Y%m%d%H%M%S")"
   cp "${NS_FILE}"{,.bak-${curdate}}
   [ "${NS_WRITEPROTECT}" = "yes" ] && chattr -i "${NS_FILE}" || true
-  echo -e "# Written by ${__FILE__} @ ${curdate}\n${resolvconf}" |tee "${NS_FILE}"
+  resolvconf="# Written by ${__FILE__} @ ${curdate}
+${resolvconf}"
+  tmpfile="${NS_FILE}.tmp"
+  echo "$resolvconf" > $tmpfile
+  # paranoid check if file has changed since written
+  if diff $tmpfile <(echo "$resolvconf"); then
+    # atomic copy
+    mv $tmpfile $NS_FILE
+  else
+    emergency "Temp file ${tempfile} changed since creation"
+  fi
   [ "${NS_WRITEPROTECT}" = "yes" ] && chattr +i "${NS_FILE}"
 
   # Folks will want to know about this


### PR DESCRIPTION
First of all, I really like your solution. A smart solution to keep things simple.
You may agree, creating the resolv.conf file with a tee command is not atomic at all. Especially in conjunction with the "timeout" command, you mentioned in your readme, the resolv.conf could end up in a half written state.
The chance is rather small, although it is possible.

a bash snippet to illustrate the problem:

``` bash
$ timeout -s9 0.01 printf "%s\n" {1..30000} | tee out.txt
```

May my modification is interesting for you.

Regards,
Rob
